### PR TITLE
feat(interstitial ad): adds interstitial ads

### DIFF
--- a/lib/configs/baseConfig.dart
+++ b/lib/configs/baseConfig.dart
@@ -49,6 +49,9 @@ abstract class BaseConfig {
   String get finishEmailVerificationUrl;
   String get dynamicLinkDomain;
 
+  String get iOSInterstitialAdUnitId;
+  String get androidInterstitialAdUnitId;
+  
   String get iOSSectionAdJsonLocation;
   String get androidSectionAdJsonLocation;
   String get iOSStoryAdJsonLocation;

--- a/lib/helpers/adHelper.dart
+++ b/lib/helpers/adHelper.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+import 'dart:developer';
+
+import 'package:google_mobile_ads/google_mobile_ads.dart';
+import 'package:readr_app/helpers/environment.dart';
+
+class AdHelper {
+  static final AdHelper _singleton = AdHelper._internal();
+
+  factory AdHelper() {
+    return _singleton;
+  }
+
+  int _clickCount = 0;
+
+  AdHelper._internal();
+
+  void checkToShowInterstitialAd() async{
+    _clickCount++;
+    if(_clickCount%3 == 0) {
+      String interstitialAdUnitId = Platform.isIOS
+      ? Environment().config.iOSInterstitialAdUnitId
+      : Environment().config.androidInterstitialAdUnitId;
+
+      InterstitialAd.load(
+        adUnitId: interstitialAdUnitId,
+        request: AdRequest(),
+        adLoadCallback: InterstitialAdLoadCallback(
+          onAdLoaded: (InterstitialAd ad) {
+            ad.show();
+          },
+          onAdFailedToLoad: (LoadAdError error) {
+            log('InterstitialAd failed to load: $error');
+          },
+        )
+      );
+    }
+  }
+}

--- a/lib/pages/storyPage/listening/listeningWidget.dart
+++ b/lib/pages/storyPage/listening/listeningWidget.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:readr_app/blocs/member/bloc.dart';
 import 'package:readr_app/blocs/storyPage/listening/cubit.dart';
 import 'package:readr_app/blocs/storyPage/listening/states.dart';
+import 'package:readr_app/helpers/adHelper.dart';
 import 'package:readr_app/helpers/dataConstants.dart';
 import 'package:readr_app/helpers/dateTimeFormat.dart';
 import 'package:readr_app/models/listening.dart';
@@ -218,6 +219,11 @@ class _ListeningWidget extends State<ListeningWidget> {
                   ],
                 ),
                 onTap: () {
+                  if(!_isPremium) {
+                    AdHelper adHelper = AdHelper();
+                    adHelper.checkToShowInterstitialAd();
+                  }
+                  
                   _fetchListeningStoryPageInfo(recordList[index].slug);
                 },
               );

--- a/lib/pages/storyPage/news/premiumStoryWidget.dart
+++ b/lib/pages/storyPage/news/premiumStoryWidget.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:readr_app/blocs/memberSubscriptionType/cubit.dart';
 import 'package:readr_app/blocs/storyPage/news/bloc.dart';
+import 'package:readr_app/helpers/adHelper.dart';
 import 'package:readr_app/helpers/dataConstants.dart';
 import 'package:readr_app/helpers/dateTimeFormat.dart';
 import 'package:readr_app/helpers/environment.dart';
@@ -718,6 +719,11 @@ class PremiumStoryWidget extends StatelessWidget {
         ),
       ),
       onTap: () {
+        if(story.isTruncated) {
+          AdHelper adHelper = AdHelper();
+          adHelper.checkToShowInterstitialAd();
+        }
+ 
         _fetchPublishedStoryBySlug(
           context,
           relatedItem.slug, 

--- a/lib/pages/storyPage/news/storyWidget.dart
+++ b/lib/pages/storyPage/news/storyWidget.dart
@@ -5,6 +5,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:readr_app/blocs/memberSubscriptionType/cubit.dart';
 import 'package:readr_app/blocs/storyPage/news/bloc.dart';
+import 'package:readr_app/helpers/adHelper.dart';
 import 'package:readr_app/helpers/environment.dart';
 import 'package:readr_app/helpers/dataConstants.dart';
 import 'package:readr_app/helpers/dateTimeFormat.dart';
@@ -623,6 +624,9 @@ class StoryWidget extends StatelessWidget {
         ),
       ),
       onTap: () {
+        AdHelper adHelper = AdHelper();
+        adHelper.checkToShowInterstitialAd();
+
         _fetchPublishedStoryBySlug(relatedItem.slug, relatedItem.isMemberCheck);
       },
     );

--- a/lib/pages/tabContent/listening/listeningTabContent.dart
+++ b/lib/pages/tabContent/listening/listeningTabContent.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:readr_app/blocs/listeningTabContentBloc.dart';
+import 'package:readr_app/helpers/adHelper.dart';
 import 'package:readr_app/helpers/apiResponse.dart';
 import 'package:readr_app/helpers/dataConstants.dart';
 import 'package:readr_app/helpers/remoteConfigHelper.dart';
@@ -113,8 +114,7 @@ class _ListeningTabContentState extends State<ListeningTabContent> {
               if (index == 0) {
                 return TheFirstItem(
                   record: recordList[index],
-                  onTap: () => RouteGenerator.navigateToListeningStory(
-                      recordList[index].slug),
+                  onTap: () => _navigateToListeningStory(recordList[index].slug),
                 );
               }
 
@@ -127,8 +127,7 @@ class _ListeningTabContentState extends State<ListeningTabContent> {
                     ),
                   ListItem(
                     record: recordList[index],
-                    onTap: () => RouteGenerator.navigateToListeningStory(
-                        recordList[index].slug),
+                    onTap: () => _navigateToListeningStory(recordList[index].slug),
                   ),
                   Padding(
                     padding: const EdgeInsets.only(left: 16.0, right: 16.0),
@@ -158,5 +157,12 @@ class _ListeningTabContentState extends State<ListeningTabContent> {
         ),
       ],
     );
+  }
+
+  void _navigateToListeningStory(String slug) {
+    AdHelper adHelper = AdHelper();
+    adHelper.checkToShowInterstitialAd();
+
+    RouteGenerator.navigateToListeningStory(slug);
   }
 }

--- a/lib/pages/tabContent/news/tabContent.dart
+++ b/lib/pages/tabContent/news/tabContent.dart
@@ -6,6 +6,7 @@ import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:readr_app/blocs/editorChoice/cubit.dart';
 import 'package:readr_app/blocs/editorChoice/state.dart';
 import 'package:readr_app/blocs/tabContent/bloc.dart';
+import 'package:readr_app/helpers/adHelper.dart';
 import 'package:readr_app/helpers/dataConstants.dart';
 import 'package:readr_app/helpers/environment.dart';
 import 'package:readr_app/helpers/remoteConfigHelper.dart';
@@ -304,6 +305,9 @@ class _TabContentState extends State<TabContent> {
   }
 
   void _navigateToStoryPage(Record record) {
+    AdHelper adHelper = AdHelper();
+    adHelper.checkToShowInterstitialAd();
+
     if(record.isExternal) {
       RouteGenerator.navigateToExternalStory(record.slug);
     } else {

--- a/lib/pages/tabContent/personal/default/personalTabContent.dart
+++ b/lib/pages/tabContent/personal/default/personalTabContent.dart
@@ -14,6 +14,7 @@ import 'package:readr_app/blocs/personalPage/category/states.dart';
 import 'package:readr_app/blocs/personalPage/article/bloc.dart';
 import 'package:readr_app/blocs/personalPage/article/events.dart';
 import 'package:readr_app/blocs/personalPage/article/states.dart';
+import 'package:readr_app/helpers/adHelper.dart';
 import 'package:readr_app/models/OnBoardingPosition.dart';
 import 'package:readr_app/pages/tabContent/personal/default/unsubscriptionCategoryList.dart';
 
@@ -418,9 +419,15 @@ class _PersonalTabContentState extends State<PersonalTabContent> {
           ]),
         ListItem(
           record: record,
-          onTap: () => RouteGenerator.navigateToStory(
+          onTap: () {
+            AdHelper adHelper = AdHelper();
+            adHelper.checkToShowInterstitialAd();
+            
+            RouteGenerator.navigateToStory(
               record.slug, 
-              isMemberCheck: record.isMemberCheck),
+              isMemberCheck: record.isMemberCheck
+            );
+          }
         ),
         Padding(
           padding: const EdgeInsets.only(left: 16.0, right: 16.0),

--- a/lib/widgets/carouselDisplayWidget.dart
+++ b/lib/widgets/carouselDisplayWidget.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:readr_app/blocs/member/bloc.dart';
+import 'package:readr_app/helpers/adHelper.dart';
 
 import 'package:readr_app/helpers/dataConstants.dart';
 import 'package:readr_app/helpers/routeGenerator.dart';
@@ -36,10 +39,14 @@ class CarouselDisplayWidget extends StatelessWidget {
         ],
       ),
       onTap: () {
+        if(!context.read<MemberBloc>().state.isPremium) {
+          AdHelper adHelper = AdHelper();
+          adHelper.checkToShowInterstitialAd();
+        }
         RouteGenerator.navigateToStory(
           record.slug, 
           isMemberCheck: record.isMemberCheck
-          );
+        );
       },
     );
   }

--- a/lib/widgets/newsMarquee/newsMarqueeWidget.dart
+++ b/lib/widgets/newsMarquee/newsMarqueeWidget.dart
@@ -1,5 +1,8 @@
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:readr_app/blocs/member/bloc.dart';
+import 'package:readr_app/helpers/adHelper.dart';
 import 'package:readr_app/helpers/firebaseAnalyticsHelper.dart';
 import 'package:readr_app/helpers/dataConstants.dart';
 import 'package:readr_app/helpers/routeGenerator.dart';
@@ -71,6 +74,10 @@ class _MarqueeWidgetState extends State<NewsMarqueeWidget> {
             slug: recordList[i].slug, 
             title: recordList[i].title
           );
+          if(!context.read<MemberBloc>().state.isPremium) {
+            AdHelper adHelper = AdHelper();
+            adHelper.checkToShowInterstitialAd();
+          }
           RouteGenerator.navigateToStory(
             recordList[i].slug, 
             isMemberCheck: recordList[i].isMemberCheck


### PR DESCRIPTION
新增插頁式廣告到編輯精選、新聞快訊、所有文章列表頁、所有相關文章
廣告出現邏輯為
1. 總計點選3次(`count%3==0`)會跳出插頁式廣告
2. 只出現於非訂閱會員狀態中