### PR TITLE
refactor(ErrorLogHelper): replace with Firebase Crashlytics

### DIFF
--- a/lib/blocs/storyPage/news/bloc.dart
+++ b/lib/blocs/storyPage/news/bloc.dart
@@ -60,12 +60,8 @@ class StoryBloc extends Bloc<StoryEvents, StoryState> with Logger {
       }
 
       emit(StoryState.loaded(storySlug: event.slug, storyRes: storyRes));
-    } catch (e) {
-      _errorLogHelper.record(
-        event.eventName(),
-        event.eventParameters(),
-        e.toString(),
-      );
+    } catch (e, s) {
+      _errorLogHelper.record(e, s);
       emit(StoryState.error(
           storySlug: event.slug,
           errorMessages: UnknownException(e.toString())));

--- a/lib/configs/baseConfig.dart
+++ b/lib/configs/baseConfig.dart
@@ -1,6 +1,5 @@
 abstract class BaseConfig {
   String get mirrorMediaDomain;
-  String get errorLogName;
 
   String get apiBase;
   String get storyPageApi;

--- a/lib/configs/baseConfig.dart
+++ b/lib/configs/baseConfig.dart
@@ -7,7 +7,6 @@ abstract class BaseConfig {
   String get topicListApi;
   String get memberApi;
   String get tokenStateApi;
-  String get errorLogApi;
 
   String get monthSubscriptionId;
   String get verifyAndroidPurchaseApi;

--- a/lib/helpers/error_log_helper.dart
+++ b/lib/helpers/error_log_helper.dart
@@ -1,38 +1,9 @@
-import 'dart:io';
-import 'dart:convert';
-
-import 'package:firebase_auth/firebase_auth.dart';
-import 'package:package_info_plus/package_info_plus.dart';
-import 'package:readr_app/helpers/api_base_helper.dart';
-import 'package:readr_app/helpers/environment.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 
 class ErrorLogHelper {
-  final ApiBaseHelper _apiBaseHelper = ApiBaseHelper();
-
-  Future<bool> record(
-    String eventName,
-    Map? eventParametersMap,
-    String errorMessage,
-  ) async {
-    FirebaseAuth auth = FirebaseAuth.instance;
-    PackageInfo packageInfo = await PackageInfo.fromPlatform();
-    Map bodyString = {
-      'eventName': eventName,
-      'eventParameters': eventParametersMap,
-      'firebaseId': auth.currentUser?.uid,
-      'user': auth.currentUser?.email,
-      'OS': Platform.operatingSystem,
-      'appVersion': packageInfo.version.toLowerCase(),
-      'errorMessage': errorMessage,
-    };
-
-    final jsonResponse = await _apiBaseHelper.postByUrl(
-      '${Environment().config.errorLogApi}?logName=${Environment().config.errorLogName}',
-      jsonEncode(bodyString),
-      headers: {"Content-Type": "application/json"},
-    );
-
-    return jsonResponse.containsKey('msg') &&
-        jsonResponse['msg'] == 'Received.';
+  Future<void> record(dynamic exception, StackTrace? stack) async {
+    if (FirebaseCrashlytics.instance.isCrashlyticsCollectionEnabled) {
+      FirebaseCrashlytics.instance.recordError(exception, stack);
+    }
   }
 }

--- a/lib/helpers/firebase_messaging_helper.dart
+++ b/lib/helpers/firebase_messaging_helper.dart
@@ -55,20 +55,18 @@ class FirebaseMessangingHelper with Logger {
             RouteGenerator.navigateToStory(fcmData.slug!);
           }
         }
-      } catch (e) {
+      } catch (e, s) {
         String? slug = fcmData?.slug;
         ErrorLogHelper().record(
-          "Firebase Messaging NavigateToStoryPage",
-          {"fcmDataSlug": slug},
-          e.toString(),
-        );
+            Exception(
+                '[Firebase Messaging NavigateToStoryPage] fcmDataSlug: $slug'),
+            s);
       }
     } else {
       ErrorLogHelper().record(
-        "Firebase Messaging NavigateToStoryPage",
-        null,
-        "RemoteMessage is null",
-      );
+          Exception(
+              '[Firebase Messaging NavigateToStoryPage] RemoteMessage is null'),
+          StackTrace.current);
     }
   }
 

--- a/lib/pages/home/default/home_page.dart
+++ b/lib/pages/home/default/home_page.dart
@@ -83,10 +83,6 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
       title: const Text(appTitle),
       actions: <Widget>[
         IconButton(
-          onPressed: () => throw Exception(),
-          icon: const Icon(Icons.error_outline),
-        ),
-        IconButton(
           icon: const Icon(Icons.search),
           tooltip: 'Search',
           onPressed: () => RouteGenerator.navigateToSearch(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # iOS and android is the same version
 
-version: 5.3.0+401
+version: 5.3.1+401
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
## Notable Changes
* Remove test button
* Change ErrorLogHelper behavior, send errors to Firebase Crashlytics instead of self-hosted API
* Remove errorLogName and errorLogApi in Config
* Bump version to 5.3.1